### PR TITLE
Correct Django syntax error with python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         'channels==2.1.2',
-        'Django==1.11.7',
+        'Django==1.11.17',
         'websocket-client==0.48.0',
         'requests==2.19.1'
     ]


### PR DESCRIPTION
Corrects a syntax error arising since python 3.7 just changing the django version to the minimum compatible. See also https://stackoverflow.com/questions/51265858/syntaxerror-generator-expression-must-be-parenthesized